### PR TITLE
Hex lengths for windbg's unassemble commands

### DIFF
--- a/windbglib.py
+++ b/windbglib.py
@@ -1215,7 +1215,7 @@ class Debugger:
 
 	def disasmForward(self,address,depth=0):
 		# go to correct location
-		cmd2run = "u 0x%08x L%d" % (address,depth+1)
+		cmd2run = "u 0x%08x L%x" % (address,depth+1)
 		try:
 			disasmlist = pykd.dbgCommand(cmd2run)
 			disasmLinesTmp = disasmlist.split("\n")
@@ -1245,7 +1245,7 @@ class Debugger:
 
 	def disasmBackward(self,address,depth):
 		while True:
-			cmd2run = "ub 0x%08x L%d" % (address,depth)
+			cmd2run = "ub 0x%08x L%x" % (address,depth)
 			try:
 				disasmlist = pykd.dbgCommand(cmd2run)
 				disasmLinesTmp = disasmlist.split("\n")


### PR DESCRIPTION
Apparently these parameters take hex values. Not sure whether this is too relevant (maybe also see related [line in mona.py](https://github.com/corelan/mona/blob/master/mona.py#L14110)).