### PR TITLE
TEB in x64 Windbg and x86 bin

### DIFF
--- a/windbglib.py
+++ b/windbglib.py
@@ -53,7 +53,7 @@ global InstructionCache
 global PageSections
 global ModuleCache
 global cpebaddress
-global PEBModList 
+global PEBModList
 
 arch = 32
 cpebaddress = 0
@@ -180,7 +180,7 @@ def getTEBAddress():
 		tebline = teblines[0]
 		tebparts = tebline.split(" ")
 		if len(tebparts) > 2:
-			return hexStrToInt(tebparts[2])
+			return hexStrToInt(tebparts[-1])
 	# slow
 	teb = getTEBInfo()
 	return int(teb.Self)


### PR DESCRIPTION
When debugging x86 binary with x64 Windbg, the `!teb` command will return a string with the first line `Wow64 TEB32 at 7efda000` ,  causing the `getTEBAddress()` function in windbglib.py to return a TEB of 0x00000000 due to a wrong argument being passed.

```
def getTEBAddress():
	tebinfo = pykd.dbgCommand("!teb")
	if len(tebinfo) > 0:
		teblines = tebinfo.split("\n")
		tebline = teblines[0]
		tebparts = tebline.split(" ")
		if len(tebparts) > 2:
			return hexStrToInt(tebparts[2]) // error - calling hexStrToInt("at")
```

x64 Windbg and x86 bin:
![image](https://user-images.githubusercontent.com/1904543/151724675-212bb5c5-d819-4b6a-8807-ea312ee63df9.png)

x64 Windbg and x64 bin:
![image](https://user-images.githubusercontent.com/1904543/151724691-348a64aa-76f1-4d58-b329-d4f77b878466.png)
